### PR TITLE
Modify shoulda-matchers gem on gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'devise_invitable', '~> 1.7.0'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.5'
-  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git', branch: 'rails-5'
+  gem 'shoulda-matchers'
   gem 'rails-controller-testing'
   gem 'factory_girl_rails'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: 0b2e0da6035b9c45b0430bc6eb9a8bab4aeba50e
-  branch: rails-5
-  specs:
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -47,13 +39,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    autoprefixer-rails (7.1.2.2)
-      execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
-    bootstrap-sass (3.3.7)
-      autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
     builder (3.2.3)
     byebug (9.0.6)
     coffee-rails (4.2.2)
@@ -177,6 +164,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -222,7 +211,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootstrap-sass (~> 3.3.6)
   byebug
   coffee-rails (~> 4.2)
   devise (~> 4.2)
@@ -238,7 +226,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
-  shoulda-matchers!
+  shoulda-matchers
   slim
   slim-rails
   spring
@@ -252,4 +240,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.4


### PR DESCRIPTION
This pull request addresses issue #1 

The line in the gemfile that is responsible for bundler to install `shoulda-matchers` no longer reflects the instructions listed in their documentation. This PR updates that line to fix the error. 