### PR TITLE
Enhance/seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ MyReaders is a literacy programme started by TeachForMalaysia alumni that is cur
 
 The portal also has an admin interface, where the programme owners can log in and view diagnostic data across participating schools.
 
+## Setup
+
+1. Clone the repository
+```
+git clone https://github.com/terencelimsayjian/my_readers.git
+```
+
+2. Run bundler
+```
+cd my_readers
+bundle install
+```
+
+3. Set up the development database
+```
+rake db:create db:migrate dev:prime
+```
+
 ## Branch Policy
 
 We follow the [Github Flow](https://guides.github.com/introduction/flow/) when developing the application, and name our branches as follow:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,12 @@
-Admin.create(username:"admin", password:"test1234")
+seed_files = %w[admins facilitators]
 
+seed_files.each do |seed|
+  seed_path = Rails.root.join('db', 'seeds', "#{seed}.rb")
 
-Facilitator.create(email:"facilitator1@email.com", password:"test1234", full_name:"Terence Lim Say Jian", school:"SK Kampung Tunku", district:"Petaling Jaya", state:"Kuala Lumpur", phone_number:"0191234123")
-Facilitator.create(email:"facilitator2@email.com", password:"test1234", full_name:"Rachel Lim Sze Ying", school:"SK Kampung Tunku", district:"Petaling Jaya", state:"Kuala Lumpur", phone_number:"0191234123")
-Facilitator.create(email:"facilitator3@email.com", password:"test1234", full_name:"Daniel Goh Keng Yu", school:"SK Kampung Tunku", district:"Petaling Jaya", state:"Kuala Lumpur", phone_number:"0191234123")
-Facilitator.create(email:"facilitator4@email.com", password:"test1234", full_name:"Charis Goh Goh Myreaders", school:"SK Kampung Tunku", district:"Petaling Jaya", state:"Kuala Lumpur", phone_number:"0191234123")
-Facilitator.create(email:"facilitator5@email.com", password:"test1234", full_name:"Nurul Fatimah hahaha", school:"SK Kampung Tunku", district:"Petaling Jaya", state:"Kuala Lumpur", phone_number:"0191234123")
+  if File.file?(seed_path)
+    puts "Seeding #{seed.humanize} ..."
+    require seed_path
+  end
+end
+
+puts 'Done!'

--- a/db/seeds/admins.rb
+++ b/db/seeds/admins.rb
@@ -1,0 +1,1 @@
+Admin.create(username: 'admin', password: 'test1234')

--- a/db/seeds/admins.rb
+++ b/db/seeds/admins.rb
@@ -1,1 +1,3 @@
-Admin.create(username: 'admin', password: 'test1234')
+Admin.find_or_create_by!(username: 'admin') do |admin|
+  admin.password = 'test1234'
+end

--- a/db/seeds/facilitators.rb
+++ b/db/seeds/facilitators.rb
@@ -1,45 +1,45 @@
-Facilitator.create(
+Facilitator.find_or_create_by(
   email: 'facilitator1@email.com',
-  password: 'test1234',
   full_name: 'Terence Lim Say Jian',
-  school: 'SK Kampung Tunku',
+  school: 'SK Puay Chai',
   district: 'Petaling Jaya',
   state: 'Kuala Lumpur',
   phone_number: '0191234123'
-)
-Facilitator.create(
+) { |facilitator| facilitator.password = 'test1234' }
+
+Facilitator.find_or_create_by(
   email: 'facilitator2@email.com',
-  password: 'test1234',
   full_name: 'Rachel Lim Sze Ying',
-  school: 'SK Kampung Tunku',
+  school: 'SK St. Andrews',
   district: 'Petaling Jaya',
   state: 'Kuala Lumpur',
   phone_number: '0191234123'
-)
-Facilitator.create(
+) { |facilitator| facilitator.password = 'test1234' }
+
+Facilitator.find_or_create_by(
   email: 'facilitator3@email.com',
-  password: 'test1234',
   full_name: 'Daniel Goh Keng Yu',
   school: 'SK Kampung Tunku',
   district: 'Petaling Jaya',
   state: 'Kuala Lumpur',
   phone_number: '0191234123'
-)
-Facilitator.create(
+) { |facilitator| facilitator.password = 'test1234' }
+
+Facilitator.find_or_create_by(
   email: 'facilitator4@email.com',
-  password: 'test1234',
   full_name: 'Charis Ding',
-  school: 'SK Kampung Tunku',
+  school: 'SK Taman Mydin',
   district: 'Petaling Jaya',
   state: 'Kuala Lumpur',
   phone_number: '0191234123'
-)
-Facilitator.create(
+) { |facilitator| facilitator.password = 'test1234' }
+
+Facilitator.find_or_create_by(
   email: 'facilitator5@email.com',
-  password: 'test1234',
-  full_name: 'Nurul Fatimah hahaha',
-  school: 'SK Kampung Tunku',
+  full_name: 'Nurul Fatimah',
+  school: 'SK Taman Megah',
   district: 'Petaling Jaya',
   state: 'Kuala Lumpur',
   phone_number: '0191234123'
-)
+) { |facilitator| facilitator.password = 'test1234' }
+

--- a/db/seeds/facilitators.rb
+++ b/db/seeds/facilitators.rb
@@ -1,0 +1,45 @@
+Facilitator.create(
+  email: 'facilitator1@email.com',
+  password: 'test1234',
+  full_name: 'Terence Lim Say Jian',
+  school: 'SK Kampung Tunku',
+  district: 'Petaling Jaya',
+  state: 'Kuala Lumpur',
+  phone_number: '0191234123'
+)
+Facilitator.create(
+  email: 'facilitator2@email.com',
+  password: 'test1234',
+  full_name: 'Rachel Lim Sze Ying',
+  school: 'SK Kampung Tunku',
+  district: 'Petaling Jaya',
+  state: 'Kuala Lumpur',
+  phone_number: '0191234123'
+)
+Facilitator.create(
+  email: 'facilitator3@email.com',
+  password: 'test1234',
+  full_name: 'Daniel Goh Keng Yu',
+  school: 'SK Kampung Tunku',
+  district: 'Petaling Jaya',
+  state: 'Kuala Lumpur',
+  phone_number: '0191234123'
+)
+Facilitator.create(
+  email: 'facilitator4@email.com',
+  password: 'test1234',
+  full_name: 'Charis Ding',
+  school: 'SK Kampung Tunku',
+  district: 'Petaling Jaya',
+  state: 'Kuala Lumpur',
+  phone_number: '0191234123'
+)
+Facilitator.create(
+  email: 'facilitator5@email.com',
+  password: 'test1234',
+  full_name: 'Nurul Fatimah hahaha',
+  school: 'SK Kampung Tunku',
+  district: 'Petaling Jaya',
+  state: 'Kuala Lumpur',
+  phone_number: '0191234123'
+)

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,19 @@
+if Rails.env.development? || Rails.env.test? || Rails.env.staging?
+
+  namespace :dev do
+    desc 'Sample data for local development'
+    task prime: :environment do
+      execute = proc do |seed|
+        seed_path = Rails.root.join('db', 'seeds', "#{seed}.rb")
+        if File.file?(seed_path)
+          print "Seeding #{seed} ..."
+          require seed_path
+          puts 'Done!'
+        end
+      end
+
+      %w[admins facilitators].each(&execute)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR enhances the current seeding experience with the following: 

1. Seed data has been moved to a rake task. Developers can now run `rake dev:prime` to seed development data in `development`, `test` and `staging` environments. 

This frees up the original `rake db:seed` for actual seed data to be used in production (e.g. the creation of admin accounts for initial users like Charis etc)

2. The seed files themselves have been made idempotent. 