### PR TITLE
Feature/new project

### DIFF
--- a/app/assets/stylesheets/common/form.scss
+++ b/app/assets/stylesheets/common/form.scss
@@ -7,7 +7,6 @@
 
   .adjacent-form-group-container {
     display: flex;
-    display: flex;
     flex-direction: row;
     justify-content: space-between;
 
@@ -61,5 +60,4 @@
     padding-top: 5px;
   }
 }
-
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,10 +1,29 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_admin
+  before_action :prepare_facilitator, only: [:new, :create]
 
   def new
+    @project = @facilitator.projects.build
   end
 
   def create
+    @project = @facilitator.projects.build(project_params)
+    if @project.save
+      flash[:notice] = 'Project successfully created'
+      redirect_to facilitators_path
+    else
+      flash[:alert] = @project.errors.full_messages.to_sentence
+      render :new
+    end
   end
 
+  private
+
+  def prepare_facilitator
+    @facilitator = Facilitator.find(params[:facilitator_id])
+  end
+
+  def project_params
+    params.require(:project).permit(:name, :estimated_start_date, :estimated_end_date)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,16 @@
 class Project < ApplicationRecord
   belongs_to :facilitator
+
+  validates :name, presence: true
+  validate :estimated_dates_are_valid?
+
+  private
+
+  def estimated_dates_are_valid?
+    errors.add(:estimated_end_date, 'must be later than start date') unless dates_are_present? && estimated_end_date > estimated_start_date
+  end
+
+  def dates_are_present?
+    estimated_start_date.present? && estimated_end_date.present?
+  end
 end

--- a/app/views/facilitators/index.html.slim
+++ b/app/views/facilitators/index.html.slim
@@ -35,4 +35,4 @@
       li
         p = facilitator.phone_number
       li
-        a href=root_url Add Project
+        = link_to 'Add Project', new_facilitator_project_path(facilitator)

--- a/app/views/projects/new.html.slim
+++ b/app/views/projects/new.html.slim
@@ -1,1 +1,19 @@
-h1 Ola
+.form-container
+  = form_for @project, url: facilitator_projects_path(@project.facilitator) do |f|
+
+    .adjacent-form-group-container
+      h3 Create a new Project
+      = f.submit 'Submit', class: 'link-btn'
+
+    .form-group
+      = f.label 'Project Name'
+      = f.text_field :name, class: 'form-input'
+
+    .form-group
+      = f.label 'Estimated Start Date'
+      = f.date_field :estimated_start_date, class: 'form-input'
+
+    .form-group
+      = f.label 'Estimated End Date'
+      = f.date_field :estimated_end_date, class: 'form-input'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,12 +8,11 @@ Rails.application.routes.draw do
   devise_for :admins, controllers: { sessions: 'admins/sessions' }
 
   root 'static_pages#index'
+
   get 'static_pages/index'
   get 'static_pages/facilitator_home'
 
-  get '/facilitators' => 'facilitators#index'
-
-  resources :facilitators, only: [:show] do
-    resources :projects, only: [:new, :create], controller: 'projects'
+  resources :facilitators, only: [:show, :index] do
+    resources :projects, only: [:new, :create]
   end
 end

--- a/db/migrate/20170721072235_create_projects.rb
+++ b/db/migrate/20170721072235_create_projects.rb
@@ -1,8 +1,10 @@
 class CreateProjects < ActiveRecord::Migration[5.1]
   def change
     create_table :projects do |t|
-      t.string :name
       t.belongs_to :facilitator, index: true
+      t.string :name, null: false
+      t.date :estimated_start_date, null: false
+      t.date :estimated_end_date, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,8 +59,10 @@ ActiveRecord::Schema.define(version: 20170721072235) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string "name"
     t.bigint "facilitator_id"
+    t.string "name", null: false
+    t.date "estimated_start_date", null: false
+    t.date "estimated_end_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["facilitator_id"], name: "index_projects_on_facilitator_id"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -25,11 +25,33 @@ RSpec.describe ProjectsController, type: :controller do
         get :new, params: { facilitator_id: facilitator.id }
         expect(response).to render_template(:new)
       end
+    end
+  end
 
-      # expect(assigns(:facilitators).count).to eq(3)
+  describe "#create" do
+    let!(:facilitator) { create(:facilitator) }
+    let!(:admin) { create(:admin) }
+
+    before { sign_in admin }
+
+    context 'when project creation succeeds' do
+      it 'should redirect to facilitators#index' do
+        post :create, params: {
+          facilitator_id: facilitator.id,
+          project: attributes_for(:project)
+        }
+        expect(response).to redirect_to(facilitators_path)
+      end
     end
 
-
-
+    context 'when project creation fails' do
+      it 'should render projects#new' do
+        post :create, params: {
+          facilitator_id: facilitator.id,
+          project: attributes_for(:project, :invalid)
+        }
+        expect(response).to render_template(:new)
+      end
+    end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,6 +1,12 @@
 FactoryGirl.define do
   factory :project do
-    name "MyString"
-    facilitator_id 27
+    association :facilitator
+    name 'MyString'
+    estimated_start_date { Date.current }
+    estimated_end_date { Date.current + 7.days }
+
+    trait :invalid do
+      estimated_end_date Date.current - 7.days
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Project, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:subject) { create(:project) }
+
+  it { expect(subject).to validate_presence_of(:name) }
+
+  describe 'custom validations' do
+    context 'when end date is later than start date' do
+      it { expect(subject.valid?).to be(true) }
+    end
+
+    context 'when end date is earlier than start date' do
+      let(:subject) { build(:project, :invalid) }
+      it { expect(subject.valid?).to be(false) }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,13 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true


### PR DESCRIPTION
##  User story: As an admin, I want to be able to add projects and students to a facilitator

### This PR allows admins to create projects for facilitators. 

The `Student` model and the feature to add `Student`s to projects will be pushed in a separate PR to keep the size of the PR small. Additionally, some housekeeping is needed before progressing further into the user story. 

Note: the migration file for projects have been modified to include `estimated_start_date` and `estimated_end_date`. The decision to modify the migration instead of creating a new migration to add to an existing table was made so as to preserve migration files simplicity and readability. Therefore, after this PR is merged, you will need to run `rake db:drop db:migrate db:seed` again. 

## Screenshots 
![screencapture-localhost-3000-facilitators-1-projects-new-1513175799917](https://user-images.githubusercontent.com/19161092/33944118-21618e88-e056-11e7-9936-1d5b77687d7d.png)
![screencapture-localhost-3000-facilitators-1513175788630](https://user-images.githubusercontent.com/19161092/33944115-1be5c910-e056-11e7-81a0-5193abcf427e.png)
