### PR TITLE
Enhance/rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,74 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  Exclude:
+    - .gems/**/*
+    - bin/**/*
+    - config/**/*
+    - db/**/*
+    - log/**/*
+    - public/**/*
+    - tmp/**/*
+    - vendor/**/*
+    - spec/rails_helper.rb
+    - spec/spec_helper.rb
+    - spec/**/*
+    - config.ru
+    - Guardfile
+    - Rakefile
+    - app/channels/**/*
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: empty_lines
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 40
+  Exclude:
+    - app/controllers/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - lib/tasks/**/*
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/LineLength:
+  Enabled: false
+
+Rails:
+  Enabled: true
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/PredicateName:
+  Exclude:
+    - lib/active_model_serializers_matchers/**/*
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Style/WordArray:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'rubocop', require: false
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,23 @@
 source 'https://rubygems.org'
 
 git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
 end
 
-ruby "2.4.1"
+ruby '2.4.1'
 
-gem 'rails', '~> 5.1.1'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
+gem 'rails', '~> 5.1.1'
 
-gem 'sass-rails', '~> 5.0'
 gem 'jquery-rails'
+gem 'sass-rails', '~> 5.0'
 
-gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
-gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
+gem 'turbolinks', '~> 5'
+gem 'uglifier', '>= 1.3.0'
 
 gem 'slim'
 gem 'slim-rails'
@@ -27,19 +27,19 @@ gem 'devise_invitable', '~> 1.7.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails', '~> 3.5'
-  gem 'shoulda-matchers'
-  gem 'rails-controller-testing'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'rails-controller-testing'
+  gem 'rspec-rails', '~> 3.5'
+  gem 'shoulda-matchers'
 end
 
 group :development do
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'rubocop', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'rubocop', require: false
+  gem 'web-console', '>= 3.3.0'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
+    ast (2.3.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
@@ -100,7 +101,11 @@ GEM
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     orm_adapter (0.5.0)
+    parallel (1.12.0)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     pg (0.21.0)
+    powerpack (0.1.1)
     puma (3.9.1)
     rack (2.0.3)
     rack-test (0.6.3)
@@ -132,6 +137,8 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -156,6 +163,14 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     sass (3.4.25)
     sass-rails (5.0.6)
@@ -196,6 +211,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.3.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -225,6 +241,7 @@ DEPENDENCIES
   rails (~> 5.1.1)
   rails-controller-testing
   rspec-rails (~> 3.5)
+  rubocop
   sass-rails (~> 5.0)
   shoulda-matchers
   slim

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Local development branch naming:
 - `enhance/<your-branch-name>` for minor feature or function enhancement
 - `bugfix/<your-branch-name>` for bug fixes
 
+### Style policy
+
+Rubocop is used to enforce a consistent code style across the codebase. The rules can be found in `.rubocop.yml`.
+
+If you are contributing to the codebase, please ensure you run `$ rubocop` from your terminal to run the code analyser on your code before pushing.
+
 ## ERD
 
 https://www.lucidchart.com/invitations/accept/a36d5480-8344-4a62-9f18-08e41ea58442

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Admins::SessionsController < Devise::SessionsController
+
   before_action :configure_sign_in_params, only: [:create]
   layout 'no_nav_bar'
 
@@ -7,4 +8,5 @@ class Admins::SessionsController < Devise::SessionsController
   def configure_sign_in_params
     devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
   end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,11 @@
 class ApplicationController < ActionController::Base
+
   protect_from_forgery with: :exception
 
   protected
 
   def authenticate_inviter!
-    authenticate_admin!(:force => true)
+    authenticate_admin!(force: true)
   end
 
   def authenticate_admin
@@ -18,4 +19,5 @@ class ApplicationController < ActionController::Base
       static_pages_facilitator_home_path
     end
   end
+
 end

--- a/app/controllers/facilitators/invitations_controller.rb
+++ b/app/controllers/facilitators/invitations_controller.rb
@@ -1,4 +1,5 @@
 class Facilitators::InvitationsController < Devise::InvitationsController
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
@@ -6,4 +7,5 @@ class Facilitators::InvitationsController < Devise::InvitationsController
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:invite, keys: [:email, :full_name, :school, :district, :state, :phone_number])
   end
+
 end

--- a/app/controllers/facilitators/sessions_controller.rb
+++ b/app/controllers/facilitators/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Facilitators::SessionsController < Devise::SessionsController
+
   layout 'no_nav_bar'
 
   # before_action :configure_sign_in_params, only: [:create]
@@ -24,4 +25,5 @@ class Facilitators::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
 end

--- a/app/controllers/facilitators_controller.rb
+++ b/app/controllers/facilitators_controller.rb
@@ -1,12 +1,11 @@
 class FacilitatorsController < ApplicationController
+
   before_action :authenticate_admin
 
   def index
     @facilitators = Facilitator.all
   end
 
-  def show
-  end
-
+  def show; end
 
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,5 @@
 class ProjectsController < ApplicationController
+
   before_action :authenticate_admin
   before_action :prepare_facilitator, only: [:new, :create]
 
@@ -26,4 +27,5 @@ class ProjectsController < ApplicationController
   def project_params
     params.require(:project).permit(:name, :estimated_start_date, :estimated_end_date)
   end
+
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,9 +1,9 @@
 class StaticPagesController < ApplicationController
+
   layout 'no_nav_bar'
 
-  def index
-  end
+  def index; end
 
-  def facilitator_home
-  end
+  def facilitator_home; end
+
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
+
   default from: 'from@example.com'
   layout 'mailer'
+
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,4 +1,6 @@
 class Admin < ApplicationRecord
-  devise :database_authenticatable, :trackable, :rememberable, :authentication_keys => [:username]
+
+  devise :database_authenticatable, :trackable, :rememberable, authentication_keys: [:username]
   include DeviseInvitable::Inviter
+
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
+
   self.abstract_class = true
+
 end

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -1,14 +1,16 @@
 class Facilitator < ApplicationRecord
+
   devise :database_authenticatable, :recoverable,
          :rememberable, :trackable, :validatable,
          :invitable, invite_for: 2.weeks, validate_on_invite: true
 
   has_many :projects
 
-  validates :email, presence: true, format: { with: /\A[\w.!#$%&’*+\/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+\z/}
+  validates :email, presence: true, format: { with: /\A[\w.!#$%&’*+\/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+\z/ }
   validates :full_name, presence: true
   validates :school, presence: true
   validates :district, presence: true
   enum state: [:johor, :kedah, :kelantan, :kuala_lumpur, :labuan, :melaka, :negeri_sembilan, :pahang, :perak, :perlis, :penang, :putrajaya, :sabah, :sarawak, :selangor, :terengganu]
   validates :phone_number, presence: true, numericality: { only_integer: true }
+
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+
   belongs_to :facilitator
 
   validates :name, presence: true
@@ -13,4 +14,5 @@ class Project < ApplicationRecord
   def dates_are_present?
     estimated_start_date.present? && estimated_end_date.present?
   end
+
 end

--- a/app/views/admins/sessions/new.html.slim
+++ b/app/views/admins/sessions/new.html.slim
@@ -1,5 +1,5 @@
 .my-readers-logo
-  = image_tag("my-readers-logo.png")
+  = image_tag('my-readers-logo.png')
 
 .form-container
   h3 Admin Login
@@ -9,16 +9,16 @@
   = form_for resource, as: resource_name, url: session_path(resource_name) do |f|
     div.form-group
       = f.label 'Username'
-      = f.text_field :username, autofocus: true, required: true, class: "form-input"
+      = f.text_field :username, autofocus: true, required: true, class: 'form-input'
 
     div.form-group
       = f.label 'Password'
-      = f.text_field :password, autocomplete: 'off', type: "password", class: "form-input"
+      = f.text_field :password, autocomplete: 'off', type: 'password', class: 'form-input'
 
     - if devise_mapping.rememberable?
       div.form-group
         = f.check_box :remember_me
-        = f.label :remember_me, class: "form-check-label"
+        = f.label :remember_me, class: 'form-check-label'
 
     div.form-group
-      = f.submit 'Log in', class: "form-submit-button"
+      = f.submit 'Log in', class: 'form-submit-button'

--- a/app/views/common/_navbar.html.slim
+++ b/app/views/common/_navbar.html.slim
@@ -1,10 +1,10 @@
 header.nav.navbar
   .nav-container
     .navbar-brand
-        a href="#" Admin Dashboard
+        a href='#' Admin Dashboard
 
     ul.nav
-      li = link_to("Facilitators", facilitators_url)
+      li = link_to('Facilitators', facilitators_url)
 
     ul.nav.navbar-right
       - if admin_signed_in?

--- a/app/views/facilitators/index.html.slim
+++ b/app/views/facilitators/index.html.slim
@@ -1,7 +1,7 @@
 .header-container
   .container
     h3 Facilitators
-    = link_to "Invite New Facilitator", new_facilitator_invitation_url, class: "link-btn"
+    = link_to 'Invite New Facilitator', new_facilitator_invitation_url, class: 'link-btn'
 
 .table-container
   ul.header-row

--- a/app/views/facilitators/invitations/edit.html.slim
+++ b/app/views/facilitators/invitations/edit.html.slim
@@ -9,11 +9,11 @@
     div.form-group
       - if f.object.class.require_password_on_accepting
         = f.label :password
-        = f.password_field :password, class: "form-input", required: true, minlength: 8, maxLength: 24
+        = f.password_field :password, class: 'form-input', required: true, minlength: 8, maxLength: 24
 
     div.form-group
       = f.label :password_confirmation
-      = f.password_field :password_confirmation, class: "form-input", required: true, minlength: 8, maxLength: 24
+      = f.password_field :password_confirmation, class: 'form-input', required: true, minlength: 8, maxLength: 24
 
     div.form-group
-      = f.submit "Set my password", class: "form-submit-button"
+      = f.submit 'Set my password', class: 'form-submit-button'

--- a/app/views/facilitators/invitations/new.html.slim
+++ b/app/views/facilitators/invitations/new.html.slim
@@ -6,28 +6,28 @@
 
     div.form-group
       = f.label :email
-      = f.text_field :email, type: "email", class: "form-input", required: true
+      = f.text_field :email, type: 'email', class: 'form-input', required: true
 
     div.form-group
       = f.label :full_name
-      = f.text_field :full_name, class: "form-input", required: true
+      = f.text_field :full_name, class: 'form-input', required: true
 
     div.form-group
       = f.label :school
-      = f.text_field :school, class: "form-input", required: true
+      = f.text_field :school, class: 'form-input', required: true
 
     div.form-group
       = f.label :district
-      = f.text_field :district, class: "form-input", required: true
+      = f.text_field :district, class: 'form-input', required: true
 
     div.adjacent-form-group-container
       div.form-group.left-form-group
         = f.label :state
-        = f.select :state, options_for_select(Facilitator.states.keys.map {|k| [k.humanize.capitalize, k]}), {}, { class: "form-input", required: true }
+        = f.select :state, options_for_select(Facilitator.states.keys.map {|k| [k.humanize.capitalize, k]}), {}, { class: 'form-input', required: true }
 
       div.form-group.right-form-group
         = f.label :phone_number
-        = f.text_field :phone_number, type: "number", class: "form-input", required: true
+        = f.text_field :phone_number, type: 'number', class: 'form-input', required: true
 
     div.form-group
-      = f.submit t("devise.invitations.new.submit_button"), class: "form-submit-button"
+      = f.submit t('devise.invitations.new.submit_button'), class: 'form-submit-button'

--- a/app/views/facilitators/mailer/invitation_instructions.html.erb
+++ b/app/views/facilitators/mailer/invitation_instructions.html.erb
@@ -1,11 +1,11 @@
-<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+<p><%= t('devise.mailer.invitation_instructions.hello', email: @resource.email) %></p>
 
-<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+<p><%= t('devise.mailer.invitation_instructions.someone_invited_you', url: root_url) %></p>
 
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_facilitator_invitation_url(invitation_token: @token) %></p>
+<p><%= link_to t('devise.mailer.invitation_instructions.accept'), accept_facilitator_invitation_url(invitation_token: @token) %></p>
 
 <% if @resource.invitation_due_at %>
-  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+  <p><%= t('devise.mailer.invitation_instructions.accept_until', due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
 <% end %>
 
-<p><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
+<p><%= t('devise.mailer.invitation_instructions.ignore').html_safe %></p>

--- a/app/views/facilitators/mailer/invitation_instructions.text.erb
+++ b/app/views/facilitators/mailer/invitation_instructions.text.erb
@@ -1,11 +1,11 @@
-<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+<%= t('devise.mailer.invitation_instructions.hello', email: @resource.email) %>
 
-<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+<%= t('devise.mailer.invitation_instructions.someone_invited_you', url: root_url) %>
 
 <%= accept_facilitator_invitation_url(invitation_token: @token) %>
 
 <% if @resource.invitation_due_at %>
-  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+  <%= t('devise.mailer.invitation_instructions.accept_until', due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
 <% end %>
 
-<%= strip_tags t("devise.mailer.invitation_instructions.ignore") %>
+<%= strip_tags t('devise.mailer.invitation_instructions.ignore') %>

--- a/app/views/facilitators/passwords/edit.html.slim
+++ b/app/views/facilitators/passwords/edit.html.slim
@@ -6,15 +6,15 @@
     = f.hidden_field :reset_password_token
 
     div.form-group
-      = f.label :password, "New password"
-      = f.password_field :password, autofocus: true, autocomplete: "off", class: "form-input", required: true, minlength: 8, maxLength: 24
+      = f.label :password, 'New password'
+      = f.password_field :password, autofocus: true, autocomplete: 'off', class: 'form-input', required: true, minlength: 8, maxLength: 24
 
     div.form-group
-      = f.label :password_confirmation, "Confirm new password"
-      = f.password_field :password_confirmation, autocomplete: "off", class: "form-input", required: true, minlength: 8, maxLength: 24
+      = f.label :password_confirmation, 'Confirm new password'
+      = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-input', required: true, minlength: 8, maxLength: 24
 
     div.form-group
-      = f.submit "Change my password", class: "form-submit-button"
+      = f.submit 'Change my password', class: 'form-submit-button'
 
     - if controller_name != 'sessions'
-      = link_to "Log in", new_session_path(resource_name), class: "form-link"
+      = link_to 'Log in', new_session_path(resource_name), class: 'form-link'

--- a/app/views/facilitators/passwords/new.html.slim
+++ b/app/views/facilitators/passwords/new.html.slim
@@ -6,10 +6,10 @@
 
     div.form-group
       = f.label :email
-      = f.email_field :email, autofocus: true, class: "form-input"
+      = f.email_field :email, autofocus: true, class: 'form-input'
 
     div.form-group
-      = f.submit "Send me reset password instructions", class: "form-submit-button"
+      = f.submit 'Send me reset password instructions', class: 'form-submit-button'
 
   - if controller_name != 'sessions'
-    = link_to "Log in", new_session_path(resource_name), class: "form-link"
+    = link_to 'Log in', new_session_path(resource_name), class: 'form-link'

--- a/app/views/facilitators/sessions/new.html.slim
+++ b/app/views/facilitators/sessions/new.html.slim
@@ -1,5 +1,5 @@
 .my-readers-logo
-    = image_tag("my-readers-logo.png")
+    = image_tag('my-readers-logo.png')
 
 .form-container
     h3 Log in
@@ -9,19 +9,19 @@
     = form_for resource, as: resource_name, url: session_path(resource_name) do |f|
         div.form-group
             = f.label :email
-            = f.text_field :email, type: "text", class: "form-input", autofocus: true, required: true
+            = f.text_field :email, type: 'text', class: 'form-input', autofocus: true, required: true
 
         div.form-group
             = f.label 'Password'
-            = f.text_field :password, autocomplete: 'off', type: "password", class: "form-input"
+            = f.text_field :password, autocomplete: 'off', type: 'password', class: 'form-input'
 
         - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-            = link_to "Forgot your password?", new_password_path(resource_name), { class: "form-link" }
+            = link_to 'Forgot your password?', new_password_path(resource_name), { class: 'form-link' }
 
         - if devise_mapping.rememberable?
             div.form-group
-                = f.check_box :remember_me, class: "form-check-input"
-                = f.label :remember_me, class: "form-check-label"
+                = f.check_box :remember_me, class: 'form-check-input'
+                = f.label :remember_me, class: 'form-check-label'
 
         div.form-group
-            = f.submit 'Log in', class: "form-submit-button"
+            = f.submit 'Log in', class: 'form-submit-button'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,11 +2,11 @@ doctype html
 html
   head
     title MY Readers
-    meta name="viewport" content="width=device-width, initial-scale=1.0"
-    = stylesheet_link_tag    "application", media: 'all', 'data-turbolinks-track' => 'reload'
-    = javascript_include_tag "application", 'data-turbolinks-track' => 'reload'
+    meta name='viewport' content='width=device-width, initial-scale=1.0'
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
     = csrf_meta_tags
-    = stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans|Roboto"
+    = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Open+Sans|Roboto'
 
 
   body class=css_class_for_controller_action(controller)

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    meta http-equiv="Content-Type" content="text/html; charset=utf-8"
+    meta http-equiv='Content-Type' content='text/html; charset=utf-8'
     /* Email styles need to be inline */
 
   body

--- a/app/views/layouts/no_nav_bar.html.slim
+++ b/app/views/layouts/no_nav_bar.html.slim
@@ -2,9 +2,9 @@ doctype html
 html
   head
     title MY Readers
-    meta name="viewport" content="width=device-width, initial-scale=1.0"
-    = stylesheet_link_tag    "application", media: 'all', 'data-turbolinks-track' => 'reload'
-    = javascript_include_tag "application", 'data-turbolinks-track' => 'reload'
+    meta name='viewport' content='width=device-width, initial-scale=1.0'
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
     = csrf_meta_tags
 
   body class=css_class_for_controller_action(controller)

--- a/app/views/static_pages/index.html.slim
+++ b/app/views/static_pages/index.html.slim
@@ -1,5 +1,5 @@
 div
   h1 Welcome to MYReaders!
 
-  =link_to "Facilitator Log In", new_facilitator_session_path, { class: "link-btn" }
-  =link_to "Admin Log In", new_admin_session_path, { class: "link-btn" }
+  =link_to 'Facilitator Log In', new_facilitator_session_path, { class: 'link-btn' }
+  =link_to 'Admin Log In', new_admin_session_path, { class: 'link-btn' }


### PR DESCRIPTION
Rubocop is configured in this PR to enforce a consistent style across the codebase. Notable code styles include: 

1. spaces in between class definitions
2. preference for single quotes where no string interpolation is used

The README has also been updated to inform the developer to run `rubocop` to run the code analyser. Additionally, `rubocop -a` will run rubocop with it's `autocorrect` option, automatically correcting trivial style offences for you. 