### PR TITLE
Feature/add students to projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'slim-rails'
 gem 'devise',           '~> 4.2'
 gem 'devise_invitable', '~> 1.7.0'
 
+gem 'cocoon'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.0.6)
+    cocoon (1.2.11)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -228,6 +229,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  cocoon
   coffee-rails (~> 4.2)
   devise (~> 4.2)
   devise_invitable (~> 1.7.0)
@@ -257,4 +259,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require jquery
+//= require cocoon
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .

--- a/app/assets/stylesheets/cocoon/cocoon.scss
+++ b/app/assets/stylesheets/cocoon/cocoon.scss
@@ -1,0 +1,3 @@
+.links {
+  margin: 15px 0;
+}

--- a/app/assets/stylesheets/common/form.scss
+++ b/app/assets/stylesheets/common/form.scss
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    vertical-align: middle;
 
     .form-group {
       width: 50%;

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -25,7 +25,7 @@ class Admin::ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:name, :estimated_start_date, :estimated_end_date)
+    params.require(:project).permit(:name, :estimated_start_date, :estimated_end_date, students_attributes: [:id, :name, :class_name, :phone_number, :_destroy])
   end
 
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,8 @@ class Project < ApplicationRecord
   belongs_to :facilitator
   has_many :students, dependent: :destroy
 
+  accepts_nested_attributes_for :students, allow_destroy: true
+
   validates :name, presence: true
   validate :estimated_dates_are_valid?
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 class Project < ApplicationRecord
 
   belongs_to :facilitator
+  has_many :students, dependent: :destroy
 
   validates :name, presence: true
   validate :estimated_dates_are_valid?

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,0 +1,8 @@
+class Student < ApplicationRecord
+
+  belongs_to :project
+
+  validates :name, presence: true
+  validates :class_name, presence: true
+
+end

--- a/app/views/admin/projects/_student_fields.html.slim
+++ b/app/views/admin/projects/_student_fields.html.slim
@@ -1,0 +1,12 @@
+.nested-fields
+  .adjacent-form-group-container
+    .form-group
+      = f.label :name
+      = f.text_field :name, class: 'form-input'
+    .form-group
+      = f.label :class_name
+      = f.text_field :class_name, class: 'form-input'
+    .form-group
+      = f.label :phone_number
+      = f.text_field :phone_number, class: 'form-input'
+    = link_to_remove_association 'Remove', f, class: 'link-btn'

--- a/app/views/admin/projects/new.html.slim
+++ b/app/views/admin/projects/new.html.slim
@@ -17,3 +17,7 @@
       = f.label 'Estimated End Date'
       = f.date_field :estimated_end_date, class: 'form-input'
 
+    = f.fields_for :students do |student|
+      = render 'student_fields', f: student
+    .links
+      = link_to_add_association 'Add a student', f, :students, class: 'link-btn'

--- a/db/migrate/20171222141037_create_students.rb
+++ b/db/migrate/20171222141037_create_students.rb
@@ -1,0 +1,12 @@
+class CreateStudents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :students do |t|
+      t.belongs_to :project, foreign_key: true
+      t.string :name, null: false
+      t.string :class_name, null: false
+      t.string :phone_number
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721072235) do
+ActiveRecord::Schema.define(version: 20171222141037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,4 +68,15 @@ ActiveRecord::Schema.define(version: 20170721072235) do
     t.index ["facilitator_id"], name: "index_projects_on_facilitator_id"
   end
 
+  create_table "students", force: :cascade do |t|
+    t.bigint "project_id"
+    t.string "name", null: false
+    t.string "class_name", null: false
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_students_on_project_id"
+  end
+
+  add_foreign_key "students", "projects"
 end

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -53,5 +53,57 @@ RSpec.describe Admin::ProjectsController, type: :controller do
         expect(response).to render_template(:new)
       end
     end
+
+    context 'when project creation with 2 students succeeds' do
+      let(:students_attributes) do
+        {
+          students_attributes: {
+            '0': attributes_for(:student),
+            '1': attributes_for(:student)
+          }
+        }
+      end
+      let(:params) do
+        {
+          facilitator_id: facilitator.id,
+          project: attributes_for(:project).merge(students_attributes)
+        }
+      end
+
+      it 'should redirect to facilitators#index' do
+        post :create, params: params
+        expect(response).to redirect_to(admin_facilitators_path)
+      end
+      it 'should create 2 students' do
+        post :create, params: params
+        expect(Student.count).to eq(2)
+      end
+    end
+
+    context 'when project creation with students fails' do
+      let(:students_attributes) do
+        {
+          students_attributes: {
+            '0': attributes_for(:student, :invalid),
+            '1': attributes_for(:student)
+          }
+        }
+      end
+      let(:params) do
+        {
+          facilitator_id: facilitator.id,
+          project: attributes_for(:project).merge(students_attributes)
+        }
+      end
+
+      it 'should render projects#new' do
+        post :create, params: params
+        expect(response).to render_template(:new)
+      end
+      it 'should not create any students' do
+        post :create, params: params
+        expect(Student.count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :student do
+    association :project
+    name { Faker::Name.name }
+    class_name '3 Gigih'
+    phone_number "+60171234567"
+
+    trait :without_phone_number do
+      phone_number nil
+    end
+
+    trait :invalid do
+      name nil
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Project, type: :model do
   let(:subject) { create(:project) }
 
   it { expect(subject).to belong_to(:facilitator) }
+  it { expect(subject).to have_many(:students).dependent(:destroy) }
   it { expect(subject).to validate_presence_of(:name) }
 
   describe 'custom validations' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Project, type: :model do
   let(:subject) { create(:project) }
 
+  it { expect(subject).to belong_to(:facilitator) }
   it { expect(subject).to validate_presence_of(:name) }
 
   describe 'custom validations' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Student, type: :model do
+
+  let(:subject) { create(:student) }
+
+  it { expect(subject).to belong_to(:project) }
+  it { expect(subject).to validate_presence_of(:name) }
+  it { expect(subject).to validate_presence_of(:class_name) }
+
+end


### PR DESCRIPTION
This PR allows admins to add students to projects. `gem Cocoon` is used to provide the javascript functionality of adding and removing form_fields dynamically into the form. The behaviour for adding students into projects is accomplished using Rails in-built `accepts_nested_attributes_for` helper for now, which isn't ideal, but manageable for now. 

Help is needed to style the `remove` button to be vertically centered. 

![screencapture-localhost-3000-admin-facilitators-1-projects-new-1513955164337](https://user-images.githubusercontent.com/19161092/34302723-220b530a-e76d-11e7-91e5-18a15e2a0e24.png)
