### PR TITLE
Feature/view project details

### DIFF
--- a/app/assets/stylesheets/common/flash_message.scss
+++ b/app/assets/stylesheets/common/flash_message.scss
@@ -1,7 +1,7 @@
 .flash-container {
   color: white;
   display: inline-block;
-  margin: 10px auto;
+  margin: 10px auto 0 auto;
 
   p {
     padding: 5px;

--- a/app/assets/stylesheets/common/label.scss
+++ b/app/assets/stylesheets/common/label.scss
@@ -2,6 +2,7 @@
   border: 1px solid black;
   border-radius: 2px;
   display: inline-block;
+  margin-right: 10px;
 
   p {
     line-height: 0;

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -7,6 +7,10 @@ class Admin::ProjectsController < ApplicationController
     @projects = Project.all
   end
 
+  def show
+    @project = Project.find(params[:id])
+  end
+
   def new
     @project = @facilitator.projects.build
   end

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -9,7 +9,6 @@ class Admin::ProjectsController < ApplicationController
 
   def new
     @project = @facilitator.projects.build
-    @facilitator
   end
 
   def create

--- a/app/controllers/facilitator/projects_controller.rb
+++ b/app/controllers/facilitator/projects_controller.rb
@@ -6,4 +6,8 @@ class Facilitator::ProjectsController < ApplicationController
     @projects = current_facilitator.projects.all
   end
 
+  def show
+    @project = Project.find(params[:id])
+  end
+
 end

--- a/app/views/admin/facilitators/index.html.slim
+++ b/app/views/admin/facilitators/index.html.slim
@@ -2,11 +2,7 @@
   h3 Facilitators
   = link_to 'Invite New Facilitator', new_facilitator_invitation_url, class: 'link-btn'
 
-div.label-container
-  div.label-legend
-    p Total Facilitators
-  div.label-content
-    p = @facilitators.count
+= render partial: 'common/summary_label', locals: { legend: 'Total Facilitators', content: @facilitators.count }
 
 .table-container
   ul.header-row

--- a/app/views/admin/projects/_student_fields.html.slim
+++ b/app/views/admin/projects/_student_fields.html.slim
@@ -1,13 +1,10 @@
 .nested-fields
   .adjacent-form-group-container
     .form-group.left-form-group
-      /= f.label :name
       = f.text_field :name, class: 'form-input'
     .form-group.center-form-group
-      /= f.label :class_name
       = f.text_field :class_name, class: 'form-input'
     .form-group.center-form-group
-      /= f.label :phone_number
       = f.text_field :phone_number, class: 'form-input'
     .form-group.right-form-group.bottom-align-form-group
       = link_to_remove_association 'x Remove this student', f, class: 'clickable-link form-clickable-link˚'

--- a/app/views/admin/projects/index.html.slim
+++ b/app/views/admin/projects/index.html.slim
@@ -14,7 +14,7 @@
     li.header-column.large
       p # Students
     li.header-column.large
-      p Edit
+      p View
 
   - @projects.each do |project|
     ul.table-row
@@ -27,4 +27,4 @@
       li.large
         p = project.students.count
       li.large
-        = link_to 'Edit', '#', class: 'clickable-link'
+        = link_to 'View', admin_project_path(project.id), class: 'clickable-link'

--- a/app/views/admin/projects/index.html.slim
+++ b/app/views/admin/projects/index.html.slim
@@ -1,11 +1,7 @@
 .header-container
   h3 Projects
 
-div.label-container
-  div.label-legend
-    p Total Projects
-  div.label-content
-    p = @projects.count
+= render partial: 'common/summary_label', locals: { legend: 'Total Projects', content: @projects.count }
 
 .table-container
   ul.header-row

--- a/app/views/admin/projects/show.html.slim
+++ b/app/views/admin/projects/show.html.slim
@@ -1,28 +1,4 @@
-h3 Admin view
-
 .header-container
-  h3 = @project.name
+  h3 = project.name
 
-= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: @project.students.count }
-
-= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(@project.estimated_start_date) }
-
-= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(@project.estimated_end_date) }
-
-.table-container
-  ul.header-row
-    li.header-column.large
-      p Name
-    li.header-column.large
-      p Class
-    li.header-column.large
-      p Contact
-
-  - @project.students.each do |student|
-    ul.table-row
-      li.large
-        p = student.name
-      li.large
-        p = student.class_name
-      li.large
-        p = student.phone_number
+= render partial: 'common/project', locals: { project: @project }

--- a/app/views/admin/projects/show.html.slim
+++ b/app/views/admin/projects/show.html.slim
@@ -1,0 +1,28 @@
+h3 Admin view
+
+.header-container
+  h3 = @project.name
+
+= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: @project.students.count }
+
+= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(@project.estimated_start_date) }
+
+= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(@project.estimated_end_date) }
+
+.table-container
+  ul.header-row
+    li.header-column.large
+      p Name
+    li.header-column.large
+      p Class
+    li.header-column.large
+      p Contact
+
+  - @project.students.each do |student|
+    ul.table-row
+      li.large
+        p = student.name
+      li.large
+        p = student.class_name
+      li.large
+        p = student.phone_number

--- a/app/views/common/_project.html.slim
+++ b/app/views/common/_project.html.slim
@@ -1,0 +1,23 @@
+= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: project.students.count }
+
+= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(project.estimated_start_date) }
+
+= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(project.estimated_end_date) }
+
+.table-container
+  ul.header-row
+    li.header-column.large
+      p Name
+    li.header-column.large
+      p Class
+    li.header-column.large
+      p Contact
+
+  - project.students.each do |student|
+    ul.table-row
+      li.large
+        p = student.name
+      li.large
+        p = student.class_name
+      li.large
+        p = student.phone_number

--- a/app/views/common/_summary_label.html.slim
+++ b/app/views/common/_summary_label.html.slim
@@ -1,0 +1,5 @@
+div.label-container
+  div.label-legend
+    p = legend
+  div.label-content
+    p = content

--- a/app/views/facilitator/projects/index.html.slim
+++ b/app/views/facilitator/projects/index.html.slim
@@ -9,4 +9,5 @@
       p = "End Date: #{prettify_date(project.estimated_end_date)}"
       p = "Number of students enrolled: #{project.students.count}"
       .bottom-container
-        = link_to 'View', '#', class: 'link-btn'
+        = link_to 'View', facilitator_project_path(project.id), class: 'link-btn'
+

--- a/app/views/facilitator/projects/show.html.slim
+++ b/app/views/facilitator/projects/show.html.slim
@@ -1,26 +1,4 @@
 .header-container
-  h3 = @project.name
+  h3 = project.name
 
-= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: @project.students.count }
-
-= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(@project.estimated_start_date) }
-
-= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(@project.estimated_end_date) }
-
-.table-container
-  ul.header-row
-    li.header-column.large
-      p Name
-    li.header-column.large
-      p Class
-    li.header-column.large
-      p Contact
-
-  - @project.students.each do |student|
-    ul.table-row
-      li.large
-        p = student.name
-      li.large
-        p = student.class_name
-      li.large
-        p = student.phone_number
+= render partial: 'common/project', locals: { project: @project }

--- a/app/views/facilitator/projects/show.html.slim
+++ b/app/views/facilitator/projects/show.html.slim
@@ -1,0 +1,26 @@
+.header-container
+  h3 = @project.name
+
+= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: @project.students.count }
+
+= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(@project.estimated_start_date) }
+
+= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(@project.estimated_end_date) }
+
+.table-container
+  ul.header-row
+    li.header-column.large
+      p Name
+    li.header-column.large
+      p Class
+    li.header-column.large
+      p Contact
+
+  - @project.students.each do |student|
+    ul.table-row
+      li.large
+        p = student.name
+      li.large
+        p = student.class_name
+      li.large
+        p = student.phone_number

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'static_pages/facilitator_home'
 
   namespace :admin do
-    resources :projects, only: [:index]
+    resources :projects, only: [:index, :show]
 
     resources :facilitators, only: [:show, :index] do
       resources :projects, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   end
 
   namespace :facilitator do
-    resources :projects, only: [:index]
+    resources :projects, only: [:index, :show]
   end
 
   devise_for :facilitators, controllers: {

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -31,6 +31,35 @@ RSpec.describe Admin::ProjectsController, type: :controller do
     end
   end
 
+  describe '#show' do
+    context '#facilitators' do
+      context 'facilitator tries viewing admin dashboard' do
+        let!(:facilitator) { create(:facilitator) }
+        let!(:project) { create(:project) }
+
+        before { sign_in facilitator }
+
+        it 'redirects to unauthorised page' do
+          get :show, params: { id: project.id }
+          expect(response).to redirect_to(static_pages_index_path)
+        end
+      end
+    end
+
+    context 'admin views project' do
+      let!(:admin) { create(:admin) }
+      let!(:project) { create(:project) }
+
+      before { sign_in admin }
+
+      it 'should render project' do
+        get :show, params: { id: project.id }
+        expect(response).to render_template(:show)
+        expect(assigns(:project)).to eq(project)
+      end
+    end
+  end
+
   describe '#new' do
     describe '#facilitators' do
       context 'facilitator tries viewing admin dashboard' do

--- a/spec/controllers/facilitator/projects_controller_spec.rb
+++ b/spec/controllers/facilitator/projects_controller_spec.rb
@@ -1,39 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Facilitator::ProjectsController, type: :controller do
-  context 'non-logged in user tries viewing projects belonging to a facilitator' do
-    it 'redirects to unauthorised page' do
-      get :index
-      expect(response).to redirect_to(static_pages_index_path)
-    end
-    end
-
-  context 'admin cannot view projects belonging to a facilitator' do
-    let!(:admin) { create(:admin) }
-
-    before { sign_in admin }
-
-    it 'redirects to unauthorised page' do
-      get :index
-      expect(response).to redirect_to(static_pages_index_path)
-    end
+  describe '#index' do
+    context 'non-logged in user tries viewing projects belonging to a facilitator' do
+      it 'redirects to unauthorised page' do
+        get :index
+        expect(response).to redirect_to(static_pages_index_path)
+      end
     end
 
-  context 'facilitator can view projects assigned to him' do
-    let!(:facilitator) { create(:facilitator) }
-    let!(:project_1) { create(:project, facilitator: facilitator) }
-    let!(:project_2) { create(:project) }
+    context 'admin cannot view projects belonging to a facilitator' do
+      let!(:admin) { create(:admin) }
 
-    before { sign_in facilitator }
+      before { sign_in admin }
 
-    it 'renders the index page' do
-      get :index
-      expect(response).to render_template(:index)
+      it 'redirects to unauthorised page' do
+        get :index
+        expect(response).to redirect_to(static_pages_index_path)
+      end
     end
 
-    it 'should return a list of projects with students' do
-      get :index
-      expect(assigns(:projects)).to eq([project_1])
+    context 'facilitator can view projects assigned to him' do
+      let!(:facilitator) { create(:facilitator) }
+      let!(:project_1) { create(:project, facilitator: facilitator) }
+      let!(:project_2) { create(:project) }
+
+      before { sign_in facilitator }
+
+      it 'renders the index page' do
+        get :index
+        expect(response).to render_template(:index)
+      end
+
+      it 'should return a list of projects with students' do
+        get :index
+        expect(assigns(:projects)).to eq([project_1])
+      end
     end
+  end
+
+  describe '#show' do
+
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Admin, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Feature includes allowing both admin and facilitator to see an individual project's details, including students.

Both of the views for admin and facilitator are almost identical, but I decided to stick with name-spaced routes i.e. admin/project/:id, facilitator/project/:id. I kept the views more DRY through the use of partials for both the summary labels and the table. 