### PR TITLE
Feature/toggle diagnostic templates

### DIFF
--- a/app/assets/javascripts/diagnostic_new/diagnostic_level_element_constructor.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_level_element_constructor.js
@@ -1,0 +1,35 @@
+function diagnosticInputRow(inputRowIndex, numberOfTestedWords) {
+    return $(
+        '<div class="row-container input-row">' +
+            hiddenDiagnosticAttribute('reading_level', inputRowIndex, inputRowIndex + 1) +
+            hiddenDiagnosticAttribute('number_of_tested_words', inputRowIndex, numberOfTestedWords) +
+            diagnosticAttribute('phonics_score', inputRowIndex, 'phonics-score') +
+            '<div class="diagnostic-form-group">' +
+                '<p id="' + percentageWordsRecognisedID(inputRowIndex) + '"></p>' +
+            '</div>' +
+            diagnosticAttribute('fluency_score', inputRowIndex) +
+            diagnosticAttribute('comprehension_score', inputRowIndex) +
+        '</div>'
+    );
+}
+
+function hiddenDiagnosticAttribute(attribute, inputRowIndex, inputValue) {
+    var attributeName = levelAttributeInputName(attribute, inputRowIndex);
+    var attributeId = levelAttributeInputID(attribute, inputRowIndex);
+    var attributeDisplayId = levelAttributeDisplayID(attribute, inputRowIndex);
+
+    return '<div class="diagnostic-form-group">' +
+            '<input type="hidden" value=' + inputValue + ' class="diagnostic-form-input" name="' + attributeName + '" id="' + attributeId + '">' +
+            '<p id="' + attributeDisplayId + '">' + inputValue + '</p>' +
+        '</div>';
+}
+
+function diagnosticAttribute(attribute, inputRowIndex, extraClass) {
+    var attributeName = levelAttributeInputName(attribute, inputRowIndex);
+    var attributeId = levelAttributeInputID(attribute, inputRowIndex);
+    var classes = extraClass ? ['diagnostic-form-group', extraClass] : ['diagnostic-form-group'];
+
+    return '<div class="' + classes.join(' ') + '">' +
+            '<input type="number" class="diagnostic-form-input" name="' + attributeName + '" id="' + attributeId + '" required>' +
+        '</div>';
+}

--- a/app/assets/javascripts/diagnostic_new/diagnostic_level_selectors.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_level_selectors.js
@@ -1,0 +1,32 @@
+function levelAttributeInputName(attribute, inputRowIndex) {
+    return "diagnostic[levels_attributes][" + inputRowIndex + "][" + attribute + "]";
+}
+
+function levelAttributeInputID(attribute, inputRowIndex) {
+    return  'diagnostic_levels_attributes_' + inputRowIndex + '_' + attribute;
+}
+
+function levelAttributeDisplayID(attribute, inputRowIndex) {
+    return levelAttributeInputID(attribute, inputRowIndex) + "_display";
+}
+
+
+function percentageWordsRecognisedID(inputRowIndex) {
+    return "diagnostic_levels_" + inputRowIndex + "_percentage_words_recognised"
+}
+
+
+function levelAttributeInput(attribute, inputRowIndex) {
+    return $('#' + levelAttributeInputID(attribute, inputRowIndex));
+}
+
+function getNumberOfInputRows() {
+    return $(".input-row-container > div.input-row").length;
+}
+
+function getDiagnosticTemplateLevels(templateNumber) {
+    var levelsData = $("#levels_information").data().levelsInformation;
+    var templateIndex = templateNumber - 1;
+
+    return levelsData[templateIndex];
+}

--- a/app/assets/javascripts/diagnostic_new/diagnostic_level_validator.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_level_validator.js
@@ -1,4 +1,29 @@
-function DiagnosticLevelValidator() {
+function performValidations() {
+    var numberOfInputRows = getNumberOfInputRows();
+    for (var i = 0; i < numberOfInputRows; i++) {
+        (function () {
+            var phonicsScoreInput = document.getElementById(levelAttributeInputID('phonics_score', i));
+            var numberOfTestedWords = levelAttributeInput('number_of_tested_words', i).val();
+            var phonicsScore = levelAttributeInput('phonics_score', i).val();
 
+            if (!phonicsScoreLessThanTestedWords(phonicsScore, numberOfTestedWords)) {
+                phonicsScoreInput.setCustomValidity("Phonics score must be less than total number of words.");
+            }
 
+            var earlierLevelsFailScoreThreshold = !phonicsScorePassesThreshold(phonicsScore, numberOfTestedWords) && (i < numberOfInputRows - 1);
+
+            if (earlierLevelsFailScoreThreshold) {
+                phonicsScoreInput.setCustomValidity("Phonics score must be 99% or higher before proceeding to next level.");
+            }
+        })();
+    }
+}
+
+function phonicsScoreLessThanTestedWords(phonicsScore, numberOfTestedWords) {
+    return parseInt(numberOfTestedWords) >= parseInt(phonicsScore);
+}
+
+function phonicsScorePassesThreshold(phonicsScore, numberOfTestedWords) {
+    var roundedPercentageScore = parseFloat((parseFloat(phonicsScore)/numberOfTestedWords).toFixed(2));
+    return roundedPercentageScore >= 0.99;
 }

--- a/app/assets/javascripts/diagnostic_new/diagnostic_level_validator.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_level_validator.js
@@ -1,0 +1,4 @@
+function DiagnosticLevelValidator() {
+
+
+}

--- a/app/assets/javascripts/diagnostic_new/diagnostic_new.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_new.js
@@ -8,9 +8,12 @@ $(document).on('turbolinks:load', function () {
         assignScoreCalculationListener(i);
     }
 
-    $("a.add-next-level").click(addNextInputRow.bind(this, 0));
+    $("a.add-next-level").click(addNextInputRow.bind(this, 0)); // need to change template
 
     $("a.remove-latest-level").click(removeLastInputRow);
+
+    var currentDiagnosticTemplate = $(".radio-btn-input > input:checked").val();
+    updateDiagnosticTemplateToSubmitted(currentDiagnosticTemplate);
 
     $(".submit-new-diagnostic").click(performValidations);
 });
@@ -70,6 +73,10 @@ function removeLastInputRow() {
     if (getNumberOfInputRows() > 1) {
         $("div.input-row").last().remove();
     }
+}
+
+function updateDiagnosticTemplateToSubmitted (diagnosticTemplate) {
+    changeDiagnosticTemplate(diagnosticTemplate);
 }
 
 function calculatePercentage(numerator, denominator) {

--- a/app/assets/javascripts/diagnostic_new/diagnostic_new.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_new.js
@@ -19,7 +19,8 @@ $(document).on('turbolinks:load', function () {
                 phonicsScoreInput.keyup();
             }
 
-            // add next level needs to pull from new template
+            $("a.add-next-level").off("click");
+            $("a.add-next-level").click(addNextInputRow.bind(this, templateId - 1));
         }
     }
 
@@ -36,17 +37,17 @@ $(document).on('turbolinks:load', function () {
         assignScoreCalculationListener(i);
     }
 
-    $("a.add-next-level").click(addNextInputRow);
+    $("a.add-next-level").click(addNextInputRow.bind(this, 0));
 
     $("a.remove-latest-level").click(removeLastInputRow);
 
     $(".submit-new-diagnostic").click(performValidations);
 });
 
-function addNextInputRow() {
+function addNextInputRow(diagnosticTemplateIndex) {
     var levelsData = $("#levels_information").data().levelsInformation;
     var inputRowIndex = $("div.input-row").length;
-    var numberOfWords = levelsData[0][inputRowIndex]; // can check which radio button is pressed
+    var numberOfWords = levelsData[diagnosticTemplateIndex][inputRowIndex]; // can check which radio button is pressed
 
     if (inputRowIndex < 11) {
         $("div.input-row-container").append(diagnosticInputRow(inputRowIndex, numberOfWords));

--- a/app/assets/javascripts/diagnostic_new/diagnostic_new.js
+++ b/app/assets/javascripts/diagnostic_new/diagnostic_new.js
@@ -1,39 +1,10 @@
-"use strict";
-
 $(document).on('turbolinks:load', function () {
     $("#diagnostic_index_1").click(changeDiagnosticTemplate.bind(this, 1));
     $("#diagnostic_index_2").click(changeDiagnosticTemplate.bind(this, 2));
     $("#diagnostic_index_3").click(changeDiagnosticTemplate.bind(this, 3));
     $("#diagnostic_index_4").click(changeDiagnosticTemplate.bind(this, 4));
 
-    function changeDiagnosticTemplate(templateId) {
-        var existingNumberOfInputRows = $(".input-row-container > div.input-row").length;
-        var levelsData = $("#levels_information").data().levelsInformation;
-        var diagnosticTemplateData = levelsData[templateId - 1];
-        for (var i = 0; i < existingNumberOfInputRows; i++) {
-
-            replaceNumberOfWordsForLevel(i, diagnosticTemplateData[i]);
-            var phonicsScoreInput = levelAttributeInput('phonics_score', i);
-
-            if (phonicsScoreInput.val() !== "") {
-                phonicsScoreInput.keyup();
-            }
-
-            $("a.add-next-level").off("click");
-            $("a.add-next-level").click(addNextInputRow.bind(this, templateId - 1));
-        }
-    }
-
-    function replaceNumberOfWordsForLevel(index, newValue) {
-        var numberOfWordsInput = $("#" + levelAttributeInputID('number_of_tested_words', index));
-        var numberOfWordsDisplay = $("#" + levelAttributeDisplayId('number_of_tested_words', index));
-
-        numberOfWordsInput.val(newValue);
-        numberOfWordsDisplay.text(newValue);
-    }
-
-    var startingNumberOfRows = $(".input-row-container > div.input-row").length;
-    for (var i = 0; i < startingNumberOfRows; i++) {
+    for (var i = 0; i < getNumberOfInputRows(); i++) {
         assignScoreCalculationListener(i);
     }
 
@@ -44,10 +15,50 @@ $(document).on('turbolinks:load', function () {
     $(".submit-new-diagnostic").click(performValidations);
 });
 
+function changeDiagnosticTemplate(templateNumber) {
+    var existingNumberOfInputRows = getNumberOfInputRows();
+    var diagnosticTemplateData = getDiagnosticTemplateLevels(templateNumber);
+
+    for (var i = 0; i < existingNumberOfInputRows; i++) {
+        replaceNumberOfWordsForLevel(i, diagnosticTemplateData[i]);
+        var phonicsScoreInput = levelAttributeInput('phonics_score', i);
+
+        assignScoreCalculationListener(i);
+        if (phonicsScoreInput.val() !== "") {
+            phonicsScoreInput.keyup(); // to refresh scores
+        }
+
+        $("a.add-next-level").off("click");
+        $("a.add-next-level").click(addNextInputRow.bind(this, templateNumber - 1));
+    }
+}
+
+function replaceNumberOfWordsForLevel(index, newValue) {
+    var numberOfWordsInput = $("#" + levelAttributeInputID('number_of_tested_words', index));
+    var numberOfWordsDisplay = $("#" + levelAttributeDisplayID('number_of_tested_words', index));
+
+    numberOfWordsInput.val(newValue);
+    numberOfWordsDisplay.text(newValue);
+}
+
+function assignScoreCalculationListener(inputRowIndex) {
+    var phonicsScoreJqueryInput = levelAttributeInput('phonics_score', inputRowIndex);
+    var phonicsScoreHtmlInput = document.getElementById(levelAttributeInputID('phonics_score', inputRowIndex));
+    var percentageWordsRecognisedTag = $("#" + percentageWordsRecognisedID(inputRowIndex));
+    var numberOfTestedWords = levelAttributeInput('number_of_tested_words', inputRowIndex).val();
+
+    phonicsScoreJqueryInput.keyup(function () {
+        phonicsScoreHtmlInput.setCustomValidity("");
+
+        var percentageCorrect = calculatePercentage(phonicsScoreJqueryInput.val(), numberOfTestedWords);
+        percentageWordsRecognisedTag.text(percentageCorrect + "%");
+    });
+}
+
 function addNextInputRow(diagnosticTemplateIndex) {
-    var levelsData = $("#levels_information").data().levelsInformation;
-    var inputRowIndex = $("div.input-row").length;
-    var numberOfWords = levelsData[diagnosticTemplateIndex][inputRowIndex]; // can check which radio button is pressed
+    var inputRowIndex = getNumberOfInputRows();
+    var diagnosticTemplateNumber = diagnosticTemplateIndex + 1;
+    var numberOfWords = getDiagnosticTemplateLevels(diagnosticTemplateNumber)[inputRowIndex];
 
     if (inputRowIndex < 11) {
         $("div.input-row-container").append(diagnosticInputRow(inputRowIndex, numberOfWords));
@@ -56,108 +67,11 @@ function addNextInputRow(diagnosticTemplateIndex) {
 }
 
 function removeLastInputRow() {
-    var numberOfInputRows = $("div.input-row").length;
-    if (numberOfInputRows > 1) {
+    if (getNumberOfInputRows() > 1) {
         $("div.input-row").last().remove();
     }
 }
 
-function performValidations() {
-    var numberOfInputRows = $("div.input-row").length;
-    for (var i = 0; i < numberOfInputRows; i++) {
-        (function () {
-            var phonicsScoreInput = document.getElementById(levelAttributeInputID('phonics_score', i));
-            var numberOfTestedWords = levelAttributeInput('number_of_tested_words', i).val();
-            var phonicsScore = levelAttributeInput('phonics_score', i).val();
-
-            if (!phonicsScoreLessThanTestedWords(phonicsScore, numberOfTestedWords)) {
-                phonicsScoreInput.setCustomValidity("Phonics score must be less than total number of words.");
-            }
-
-            var earlierLevelsPassScoreThreshold = !phonicsScorePassesThreshold(phonicsScore, numberOfTestedWords) && (i < numberOfInputRows - 1);
-            if (earlierLevelsPassScoreThreshold) {
-                phonicsScoreInput.setCustomValidity("Phonics score must be 99% or higher before proceeding to next level.");
-            }
-        })();
-    }
-}
-
-function phonicsScoreLessThanTestedWords(phonicsScore, numberOfTestedWords) {
-    return parseInt(numberOfTestedWords) >= parseInt(phonicsScore);
-}
-
-function phonicsScorePassesThreshold(phonicsScore, numberOfTestedWords) {
-    var roundedPercentageScore = parseFloat((parseFloat(phonicsScore)/numberOfTestedWords).toFixed(2));
-    return roundedPercentageScore >= 0.99;
-}
-
-function assignScoreCalculationListener(inputRowIndex) {
-    var phonicsScoreJqueryInput = levelAttributeInput('phonics_score', inputRowIndex);
-
-    phonicsScoreJqueryInput.keyup(function () {
-        var numberOfTestedWords = levelAttributeInput('number_of_tested_words', inputRowIndex).val();
-        var phonicsScoreHtmlInput = document.getElementById(levelAttributeInputID('phonics_score', inputRowIndex));
-
-        phonicsScoreHtmlInput.setCustomValidity("");
-        var percentageWordsRecognisedTag = $("#diagnostic_levels_" + inputRowIndex + "_percentage_words_recognised");
-
-        var percentageCorrect = calculatePercentage(phonicsScoreJqueryInput.val(), numberOfTestedWords);
-        percentageWordsRecognisedTag.text(percentageCorrect + "%");
-    });
-}
-
-function diagnosticInputRow(inputRowIndex, numberOfTestedWords) {
-    return $(
-        '<div class="row-container input-row">' +
-            hiddenDiagnosticAttribute('reading_level', inputRowIndex, inputRowIndex + 1) +
-            hiddenDiagnosticAttribute('number_of_tested_words', inputRowIndex, numberOfTestedWords) +
-            diagnosticAttribute('phonics_score', inputRowIndex, 'phonics-score') +
-            '<div class="diagnostic-form-group">' +
-                '<p id="diagnostic_levels_' + inputRowIndex + '_percentage_words_recognised"></p>' +
-            '</div>' +
-            diagnosticAttribute('fluency_score', inputRowIndex) +
-            diagnosticAttribute('comprehension_score', inputRowIndex) +
-        '</div>'
-    );
-}
-
-function hiddenDiagnosticAttribute(attribute, inputRowIndex, inputValue) {
-    var attributeName = levelAttributeInputName(attribute, inputRowIndex);
-    var attributeId = levelAttributeInputID(attribute, inputRowIndex);
-    var attributeDisplayId = levelAttributeDisplayId(attribute, inputRowIndex);
-
-    return '<div class="diagnostic-form-group">' +
-                '<input type="hidden" value=' + inputValue + ' class="diagnostic-form-input" name="' + attributeName + '" id="' + attributeId + '">' +
-                '<p id="' + attributeDisplayId + '">' + inputValue + '</p>' +
-            '</div>';
-}
-
-function diagnosticAttribute(attribute, inputRowIndex, extraClass) {
-    var attributeName = levelAttributeInputName(attribute, inputRowIndex);
-    var attributeId = levelAttributeInputID(attribute, inputRowIndex);
-    var classes = extraClass ? ['diagnostic-form-group', extraClass] : ['diagnostic-form-group'];
-
-    return '<div class="' + classes.join(' ') + '">' +
-                '<input type="number" class="diagnostic-form-input" name="' + attributeName + '" id="' + attributeId + '" required>' +
-            '</div>';
-}
-
 function calculatePercentage(numerator, denominator) {
     return Math.round((numerator / denominator) * 100);
-}
-
-function levelAttributeInputName(attribute, inputRowIndex) {
-    return "diagnostic[levels_attributes][" + inputRowIndex + "][" + attribute + "]";
-}
-
-function levelAttributeInputID(attribute, inputRowIndex) {
-    return  'diagnostic_levels_attributes_' + inputRowIndex + '_' + attribute;
-}
-
-function levelAttributeDisplayId(attribute, inputRowIndex) {
-    return levelAttributeInputID(attribute, inputRowIndex) + "_display";
-}
-
-function levelAttributeInput(attribute, inputRowIndex) {
-    return $('#' + levelAttributeInputID(attribute, inputRowIndex));
 }

--- a/app/assets/stylesheets/common/diagnostic_form.scss
+++ b/app/assets/stylesheets/common/diagnostic_form.scss
@@ -5,6 +5,39 @@
   padding: 10px;
   border: 1px solid rgba(0, 0, 0, .15);
 
+  .select-current-diagnostic-text {
+    margin: 0 0 10px 0;
+    font-size: 1em;
+  }
+
+  .radio-btn-container {
+    display: flex;
+    justify-content: space-between;
+
+
+    .radio-btn-input {
+      width: 25%;
+      display: flex;
+      align-content: center;
+
+      input {
+        height: 2em;
+        width: 2em;
+        margin: 0 0 0 20px;
+      }
+
+      .radio-label-container {
+        display: flex;
+        align-items: center;
+
+        label {
+          font-size: 1em;
+        }
+      }
+
+    }
+  }
+
   .row-container {
     display: flex;
 
@@ -67,3 +100,7 @@
   }
 }
 
+.diagnostic-form-radio-btn-container {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/common/label.scss
+++ b/app/assets/stylesheets/common/label.scss
@@ -3,6 +3,7 @@
   border-radius: 2px;
   display: inline-block;
   margin-right: 10px;
+  margin-bottom: 5px;
 
   p {
     line-height: 0;

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -8,7 +8,8 @@ class Admin::ProjectsController < ApplicationController
   end
 
   def show
-    @project = Project.find(params[:id])
+    project = Project.find(params[:id])
+    @project_view_object = ProjectViewHelper::ProjectViewObject.new(project)
   end
 
   def new

--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -26,7 +26,6 @@ class DiagnosticsController < ApplicationController
       render :new and return
     end
 
-    # byebug
 
     if @diagnostic.save
       students = Student.where("project_id = ?", @student.project_id)

--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -8,7 +8,12 @@ class DiagnosticsController < ApplicationController
   def new
     @diagnostic = @student.diagnostics.build
     @diagnostic.levels.build
-    @levels_information = [100,130,140,150,160,170,180,190,200,210,220]
+    @levels_information = [
+        [101,102,103,104,105,106,107,108,109,110,111],
+        [201,202,203,204,205,206,207,208,209,210,211],
+        [301,302,303,304,305,306,307,308,309,310,311],
+        [401,402,403,404,405,406,407,408,409,410,411],
+    ]
   end
 
   def create
@@ -59,7 +64,7 @@ class DiagnosticsController < ApplicationController
   end
 
   def diagnostic_params
-    params.require(:diagnostic).permit(levels_attributes: [:id, :reading_level, :number_of_tested_words, :phonics_score, :fluency_score, :comprehension_score])
+    params.require(:diagnostic).permit(:index, levels_attributes: [:id, :reading_level, :number_of_tested_words, :phonics_score, :fluency_score, :comprehension_score])
   end
 
   def prepare_student

--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -5,27 +5,29 @@ class DiagnosticsController < ApplicationController
   before_action :authenticate_user
   before_action :prepare_student, only: [:new, :create]
 
+  LEVELS_INFORMATION = [
+      [101,102,103,104,105,106,107,108,109,110,111],
+      [201,202,203,204,205,206,207,208,209,210,211],
+      [301,302,303,304,305,306,307,308,309,310,311],
+      [401,402,403,404,405,406,407,408,409,410,411],
+  ]
+
   def new
     @diagnostic = @student.diagnostics.build
     @diagnostic.levels.build
-    @levels_information = [
-        [101,102,103,104,105,106,107,108,109,110,111],
-        [201,202,203,204,205,206,207,208,209,210,211],
-        [301,302,303,304,305,306,307,308,309,310,311],
-        [401,402,403,404,405,406,407,408,409,410,411],
-    ]
+    @levels_information = LEVELS_INFORMATION
   end
 
   def create
     diagnostic_level_validation_info = LevelsValidator.new.get_validation_info(params[:diagnostic][:levels_attributes].values)
 
     @diagnostic = @student.diagnostics.build(diagnostic_params)
+    @levels_information = LEVELS_INFORMATION
 
     unless diagnostic_level_validation_info[:is_valid]
       flash[:alert] = diagnostic_level_validation_info[:message]
       render :new and return
     end
-
 
     if @diagnostic.save
       students = Student.where("project_id = ?", @student.project_id)

--- a/app/helpers/project_view_helper.rb
+++ b/app/helpers/project_view_helper.rb
@@ -1,0 +1,49 @@
+module ProjectViewHelper
+
+  class ProjectViewObject
+    attr_accessor :project, :students, :labels
+
+    def initialize(project)
+      @project = project
+      @students = project.students.map { |student| StudentViewObject.new(student) }
+      @labels = {
+          beginning_average_reading_level: get_beginning_average_reading_level(),
+          current_average_reading_level: get_current_average_reading_level(),
+          total_students: project.students.count,
+      }
+    end
+
+    private
+
+    def get_beginning_average_reading_level
+      beginning_reading_levels = @students.map { |students| students.beginning_reading_level }
+      get_average_reading_level(beginning_reading_levels)
+    end
+
+    def get_current_average_reading_level
+      ending_reading_levels = @students.map { |students| students.current_reading_level }
+      get_average_reading_level(ending_reading_levels)
+    end
+
+    def get_average_reading_level(reading_levels)
+      totalReadingLevel = reading_levels.reduce { |acc, reading_level| acc + reading_level };
+      (totalReadingLevel.to_f / reading_levels.size).round(2)
+    end
+  end
+
+  class StudentViewObject
+    attr_accessor :id, :name, :class_name, :phone_number, :beginning_reading_level, :current_reading_level, :num_diagnostics_taken
+
+    def initialize(student)
+      @id = student.id
+      @name = student.name
+      @class_name = student.class_name
+      @phone_number = student.phone_number
+      @beginning_reading_level = student.beginning_reading_level
+      @current_reading_level = student.current_reading_level
+      @num_diagnostics_taken = student.diagnostics.count
+    end
+  end
+
+end
+

--- a/app/models/diagnostic.rb
+++ b/app/models/diagnostic.rb
@@ -1,4 +1,6 @@
 class Diagnostic < ApplicationRecord
+  default_scope { order({created_at: :asc}) }
+
   belongs_to :student
   has_many :levels, dependent: :destroy
   accepts_nested_attributes_for :levels

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -27,12 +27,13 @@ class Student < ApplicationRecord
 
   private
 
-  def getHighestReadingLevel(orderedLevels)
-    scores = orderedLevels.map {|level| PhonicsScoreUtil.calculate_percentage_correct(level, 2)}
+  def getHighestReadingLevel(ordered_levels)
+    scores = ordered_levels.map {|level| PhonicsScoreUtil.calculate_percentage_correct(level, 2)}
 
     failure_level_index = scores.index {|score| score < 0.92}
 
-    failure_level_index ? failure_level_index : 11
+    failure_level_index ? failure_level_index : ordered_levels.size
+    # if they submit a single level which passes, this results in 11 due to failure_level_index being nil
   end
 
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -13,9 +13,24 @@ class Student < ApplicationRecord
     return 0 unless latest_diagnostic
 
     levels = latest_diagnostic.levels.order(:reading_level)
-    scores = levels.map { |level| PhonicsScoreUtil.calculate_percentage_correct(level, 2) }
+    getHighestReadingLevel(levels)
+  end
 
-    failure_level_index = scores.index { | score | score < 0.92 }
+  def beginning_reading_level
+    diagnostic = self.diagnostics.order(:created_at).first
+
+    return 0 unless diagnostic
+
+    levels = diagnostic.levels.order(:reading_level)
+    getHighestReadingLevel(levels)
+  end
+
+  private
+
+  def getHighestReadingLevel(orderedLevels)
+    scores = orderedLevels.map {|level| PhonicsScoreUtil.calculate_percentage_correct(level, 2)}
+
+    failure_level_index = scores.index {|score| score < 0.92}
 
     failure_level_index ? failure_level_index : 11
   end

--- a/app/views/admin/projects/show.html.slim
+++ b/app/views/admin/projects/show.html.slim
@@ -1,5 +1,5 @@
 .header-container
-  h3 = @project.name
-  = link_to 'Edit Project Details', edit_admin_project_path(@project.id), class: 'link-btn'
+  h3 = @project_view_object.project.name
+  = link_to 'Edit Project Details', edit_admin_project_path(@project_view_object.project.id), class: 'link-btn'
 
-= render partial: 'common/project_show', locals: { project: @project }
+= render partial: 'common/project_show', locals: { project: @project_view_object }

--- a/app/views/common/_project_show.html.slim
+++ b/app/views/common/_project_show.html.slim
@@ -1,11 +1,11 @@
 div
-  = render partial: 'common/summary_label', locals: { legend: 'Beginning Ave Reading Level', content: '##' }
-  = render partial: 'common/summary_label', locals: { legend: 'Current Ave Reading Level', content: '##' }
+  = render partial: 'common/summary_label', locals: { legend: 'Beginning Ave Reading Level', content: project.labels[:beginning_average_reading_level] }
+  = render partial: 'common/summary_label', locals: { legend: 'Current Ave Reading Level', content: project.labels[:current_average_reading_level] }
 
 div
-  = render partial: 'common/summary_label', locals: { legend: 'Total Students', content: project.students.count }
-  = render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(project.estimated_start_date) }
-  = render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(project.estimated_end_date) }
+  = render partial: 'common/summary_label', locals: { legend: 'Total Students', content: project.labels[:total_students] }
+  = render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(project.project.estimated_start_date) }
+  = render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(project.project.estimated_end_date) }
 
 .table-container
   ul.header-row
@@ -33,6 +33,6 @@ div
       li.medium
         p = student.current_reading_level
       li.medium
-        p = student.diagnostics.count
+        p = student.num_diagnostics_taken
       li.medium
         = link_to '+ Add', new_student_diagnostic_path(student.id), class: 'clickable-link'

--- a/app/views/common/_project_show.html.slim
+++ b/app/views/common/_project_show.html.slim
@@ -1,8 +1,11 @@
-= render partial: 'common/summary_label', locals: { legend: 'Total Students', content: project.students.count }
+div
+  = render partial: 'common/summary_label', locals: { legend: 'Beginning Ave Reading Level', content: '##' }
+  = render partial: 'common/summary_label', locals: { legend: 'Current Ave Reading Level', content: '##' }
 
-= render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(project.estimated_start_date) }
-
-= render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(project.estimated_end_date) }
+div
+  = render partial: 'common/summary_label', locals: { legend: 'Total Students', content: project.students.count }
+  = render partial: 'common/summary_label', locals: { legend: 'Start Date', content: prettify_date(project.estimated_start_date) }
+  = render partial: 'common/summary_label', locals: { legend: 'End Date', content: prettify_date(project.estimated_end_date) }
 
 .table-container
   ul.header-row

--- a/app/views/diagnostics/new.html.slim
+++ b/app/views/diagnostics/new.html.slim
@@ -43,15 +43,15 @@
       = diagnostic_f.fields_for :levels do |f|
         .row-container.input-row
             .diagnostic-form-group
-              = f.hidden_field :reading_level, type: 'hidden', class: 'diagnostic-form-input', value: 1
-              p = 1
+              = f.hidden_field :reading_level, type: 'hidden', class: 'diagnostic-form-input', value: f.index + 1
+              p = f.index + 1
             .diagnostic-form-group
-              = f.hidden_field :number_of_tested_words, type: 'hidden', class: 'diagnostic-form-input', value: @levels_information[0][0]
-              p#diagnostic_levels_attributes_0_number_of_tested_words_display = @levels_information[0][0]
+              = f.hidden_field :number_of_tested_words, type: 'hidden', class: 'diagnostic-form-input', value:@levels_information[@diagnostic.index ? @diagnostic.index - 1 : 0][f.index]
+              = content_tag :p, @levels_information[@diagnostic.index ? @diagnostic.index - 1 : 0][f.index], id: "diagnostic_levels_attributes_#{f.index}_number_of_tested_words_display"
             .diagnostic-form-group
               = f.text_field :phonics_score, type: 'number', class: 'diagnostic-form-input phonics-score', required: true
             .diagnostic-form-group
-              p#diagnostic_levels_0_percentage_words_recognised
+              = content_tag :p, '', id: "diagnostic_levels_#{f.index}_percentage_words_recognised"
             .diagnostic-form-group
               = f.text_field :fluency_score, type: 'number', class: 'diagnostic-form-input', required: true
             .diagnostic-form-group

--- a/app/views/diagnostics/new.html.slim
+++ b/app/views/diagnostics/new.html.slim
@@ -3,14 +3,26 @@
 
 = form_for @diagnostic, url: student_diagnostic_path do |diagnostic_f|
 
-  = diagnostic_f.radio_button :index, 1, checked: true
-  = label :diagnostic, :index, 'Diagnostic 1', value: 1
-  = diagnostic_f.radio_button :index, 2
-  = label :diagnostic, :index, 'Diagnostic 2', value: 2
-  = diagnostic_f.radio_button :index, 3
-  = label :diagnostic, :index, 'Diagnostic 3', value: 3
-  = diagnostic_f.radio_button :index, 4
-  = label :diagnostic, :index, 'Diagnostic 4', value: 4
+  .diagnostic-form-container.diagnostic-form-radio-btn-container
+    p.select-current-diagnostic-text Select current diagnostic:
+
+    .radio-btn-container
+      .radio-btn-input
+        = diagnostic_f.radio_button :index, 1, checked: true
+        div.radio-label-container
+          = label :diagnostic, :index, 'Diagnostic 1', value: 1
+      .radio-btn-input
+        = diagnostic_f.radio_button :index, 2
+        div.radio-label-container
+          = label :diagnostic, :index, 'Diagnostic 2', value: 2
+      .radio-btn-input
+        = diagnostic_f.radio_button :index, 3
+        div.radio-label-container
+          = label :diagnostic, :index, 'Diagnostic 3', value: 3
+      .radio-btn-input
+        = diagnostic_f.radio_button :index, 4
+        div.radio-label-container
+          = label :diagnostic, :index, 'Diagnostic 4', value: 4
 
   .diagnostic-form-container
     .row-container

--- a/app/views/diagnostics/new.html.slim
+++ b/app/views/diagnostics/new.html.slim
@@ -1,22 +1,32 @@
 .header-container
   h3 = "Add New Diagnostic for #{@student.name} (#{@student.class_name})"
 
-.diagnostic-form-container
-  .row-container
-    .diagnostic-form-group
-      h5 Reading Level
-    .diagnostic-form-group
-      h5 # of words
-    .diagnostic-form-group
-      h5 Word Recognition
-    .diagnostic-form-group
-      h5 % Words Recognised
-    .diagnostic-form-group
-      h5 Fluency
-    .diagnostic-form-group
-      h5 Comprehension
+= form_for @diagnostic, url: student_diagnostic_path do |diagnostic_f|
 
-  = form_for @diagnostic, url: student_diagnostic_path do |diagnostic_f|
+  = diagnostic_f.radio_button :index, 1, checked: true
+  = label :diagnostic, :index, 'Diagnostic 1', value: 1
+  = diagnostic_f.radio_button :index, 2
+  = label :diagnostic, :index, 'Diagnostic 2', value: 2
+  = diagnostic_f.radio_button :index, 3
+  = label :diagnostic, :index, 'Diagnostic 3', value: 3
+  = diagnostic_f.radio_button :index, 4
+  = label :diagnostic, :index, 'Diagnostic 4', value: 4
+
+  .diagnostic-form-container
+    .row-container
+      .diagnostic-form-group
+        h5 Reading Level
+      .diagnostic-form-group
+        h5 # of words
+      .diagnostic-form-group
+        h5 Word Recognition
+      .diagnostic-form-group
+        h5 % Words Recognised
+      .diagnostic-form-group
+        h5 Fluency
+      .diagnostic-form-group
+        h5 Comprehension
+
     .input-row-container
       = diagnostic_f.fields_for :levels do |f|
         .row-container.input-row
@@ -24,12 +34,12 @@
               = f.hidden_field :reading_level, type: 'hidden', class: 'diagnostic-form-input', value: 1
               p = 1
             .diagnostic-form-group
-              = f.hidden_field :number_of_tested_words, type: 'hidden', class: 'diagnostic-form-input', value: @levels_information[0]
-              p = @levels_information[0]
+              = f.hidden_field :number_of_tested_words, type: 'hidden', class: 'diagnostic-form-input', value: @levels_information[0][0]
+              p#diagnostic_levels_attributes_0_number_of_tested_words_display = @levels_information[0][0]
             .diagnostic-form-group
               = f.text_field :phonics_score, type: 'number', class: 'diagnostic-form-input phonics-score', required: true
             .diagnostic-form-group
-              p.percentage-words-recognised
+              p#diagnostic_levels_0_percentage_words_recognised
             .diagnostic-form-group
               = f.text_field :fluency_score, type: 'number', class: 'diagnostic-form-input', required: true
             .diagnostic-form-group
@@ -46,4 +56,4 @@
       .adjacent-container
         = diagnostic_f.submit 'Submit and Go To Next Student', class: 'btn-standard submit-new-diagnostic', name: 'submit_and_go_to_next_student'
 
-  = content_tag "levels_information", nil, id: 'levels_information', data: { levels_information: @levels_information }
+    = content_tag "levels_information", nil, id: 'levels_information', data: { levels_information: @levels_information }

--- a/db/migrate/20171228060844_create_diagnostics.rb
+++ b/db/migrate/20171228060844_create_diagnostics.rb
@@ -2,6 +2,7 @@ class CreateDiagnostics < ActiveRecord::Migration[5.1]
   def change
     create_table :diagnostics do |t|
       t.references :student, foreign_key: true
+      t.integer :index, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20171228064803) do
 
   create_table "diagnostics", force: :cascade do |t|
     t.bigint "student_id"
+    t.integer "index", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["student_id"], name: "index_diagnostics_on_student_id"

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Admin::ProjectsController, type: :controller do
       it 'should render project' do
         get :show, params: { id: project.id }
         expect(response).to render_template(:show)
-        expect(assigns(:project)).to eq(project)
+        expect(assigns(:project_view_object).is_a? ProjectViewHelper::ProjectViewObject).to be_truthy
       end
     end
   end

--- a/spec/factories/diagnostics.rb
+++ b/spec/factories/diagnostics.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :diagnostic do
     association :student
+    index 1
   end
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -37,15 +37,25 @@ RSpec.describe Student, type: :model do
         let!(:level_3) { create(:level, :failing_phonics_score, diagnostic: last_diagnostic)}
 
         it 'should return 2 as current reading level' do
-          expect(student.current_reading_level).to be(2)
+          expect(student.current_reading_level).to eq(2)
         end
       end
 
-      describe 'when student fails reading level 3' do
+      describe 'when student fails reading level 1' do
         let!(:level_1) { create(:level, :failing_phonics_score, diagnostic: last_diagnostic)}
 
         it 'should return 0 as current reading level' do
-          expect(student.current_reading_level).to be(0)
+          expect(student.current_reading_level).to eq(0)
+        end
+      end
+
+      describe 'when student passes all diagnostics, but not 11 levels' do
+        let!(:level_1) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_2) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_3) { create(:level, diagnostic: last_diagnostic)}
+
+        it 'should return the latest passed diagnostic level of 3' do
+          expect(student.current_reading_level).to eq(3)
         end
       end
 
@@ -63,7 +73,7 @@ RSpec.describe Student, type: :model do
         let!(:level_11) { create(:level, phonics_score: 92, number_of_tested_words: 100, diagnostic: last_diagnostic)}
 
         it 'should return 11 as current reading level' do
-          expect(student.current_reading_level).to be(11)
+          expect(student.current_reading_level).to eq(11)
         end
       end
 
@@ -86,7 +96,7 @@ RSpec.describe Student, type: :model do
         let!(:level_3) { create(:level, :failing_phonics_score, diagnostic: first_diagnostic)}
 
         it 'should return 2 as current reading level' do
-          expect(student.beginning_reading_level).to be(2)
+          expect(student.beginning_reading_level).to eq(2)
         end
       end
 
@@ -94,13 +104,13 @@ RSpec.describe Student, type: :model do
         let!(:level_1) { create(:level, :failing_phonics_score, diagnostic: first_diagnostic)}
 
         it 'should return 0 as current reading level' do
-          expect(student.beginning_reading_level).to be(0)
+          expect(student.beginning_reading_level).to eq(0)
         end
       end
 
       describe 'when student has no diagnostics' do
         it 'should return 0 as current reading level' do
-          expect(student_2.beginning_reading_level).to be(0)
+          expect(student_2.beginning_reading_level).to eq(0)
         end
       end
 
@@ -118,7 +128,7 @@ RSpec.describe Student, type: :model do
         let!(:level_11) { create(:level, phonics_score: 92, number_of_tested_words: 100, diagnostic: first_diagnostic)}
 
         it 'should return 11 as current reading level' do
-          expect(student.beginning_reading_level).to be(11)
+          expect(student.beginning_reading_level).to eq(11)
         end
       end
 

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -24,13 +24,17 @@ RSpec.describe Student, type: :model do
   describe '#current_reading_level' do
     let!(:student) { create(:student) }
     let!(:student_2) { create(:student) }
-    let!(:diagnostic) { create(:diagnostic, student: student)}
+    let!(:first_diagnostic) { create(:diagnostic, student: student)}
+    let!(:second_diagnostic) { create(:diagnostic, student: student)}
+    let!(:last_diagnostic) { create(:diagnostic, student: student)}
+    let!(:level_1_first_diagnostic) { create(:level, diagnostic: first_diagnostic)}
+    let!(:level_1_second_diagnostic) { create(:level, diagnostic: second_diagnostic)}
 
     context 'failure occurs before level 11' do
       describe 'when student fails reading level 3' do
-        let!(:level_1) { create(:level, diagnostic: diagnostic)}
-        let!(:level_2) { create(:level, diagnostic: diagnostic)}
-        let!(:level_3) { create(:level, :failing_phonics_score, diagnostic: diagnostic)}
+        let!(:level_1) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_2) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_3) { create(:level, :failing_phonics_score, diagnostic: last_diagnostic)}
 
         it 'should return 2 as current reading level' do
           expect(student.current_reading_level).to be(2)
@@ -38,34 +42,83 @@ RSpec.describe Student, type: :model do
       end
 
       describe 'when student fails reading level 3' do
-        let!(:level_1) { create(:level, :failing_phonics_score, diagnostic: diagnostic)}
+        let!(:level_1) { create(:level, :failing_phonics_score, diagnostic: last_diagnostic)}
 
         it 'should return 0 as current reading level' do
           expect(student.current_reading_level).to be(0)
         end
       end
 
+      describe 'when student passes all reading levels' do
+        let!(:level_1) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_2) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_3) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_4) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_5) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_6) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_7) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_8) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_9) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_10) { create(:level, diagnostic: last_diagnostic)}
+        let!(:level_11) { create(:level, phonics_score: 92, number_of_tested_words: 100, diagnostic: last_diagnostic)}
+
+        it 'should return 11 as current reading level' do
+          expect(student.current_reading_level).to be(11)
+        end
+      end
+
+    end
+  end
+
+  describe '#beginning_reading_level' do
+    let!(:student) { create(:student) }
+    let!(:student_2) { create(:student) }
+    let!(:first_diagnostic) { create(:diagnostic, index: 1, student: student)}
+    let!(:second_diagnostic) { create(:diagnostic, index: 2, student: student)}
+    let!(:last_diagnostic) { create(:diagnostic, index: 4, student: student)}
+    let!(:level_1_second_diagnostic) { create(:level, :failing_phonics_score, reading_level: 1, diagnostic: second_diagnostic)}
+    let!(:level_1_last_diagnostic) { create(:level, :failing_phonics_score, reading_level: 1, diagnostic: last_diagnostic)}
+
+    context 'failure occurs before level 11' do
+      describe 'when student fails reading level 3' do
+        let!(:level_1) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_2) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_3) { create(:level, :failing_phonics_score, diagnostic: first_diagnostic)}
+
+        it 'should return 2 as current reading level' do
+          expect(student.beginning_reading_level).to be(2)
+        end
+      end
+
+      describe 'when student fails reading level 1' do
+        let!(:level_1) { create(:level, :failing_phonics_score, diagnostic: first_diagnostic)}
+
+        it 'should return 0 as current reading level' do
+          expect(student.beginning_reading_level).to be(0)
+        end
+      end
+
       describe 'when student has no diagnostics' do
         it 'should return 0 as current reading level' do
-          expect(student_2.current_reading_level).to be(0)
+          expect(student_2.beginning_reading_level).to be(0)
         end
       end
 
       describe 'when student passes all reading levels' do
-        let!(:level_1) { create(:level, diagnostic: diagnostic)}
-        let!(:level_2) { create(:level, diagnostic: diagnostic)}
-        let!(:level_3) { create(:level, diagnostic: diagnostic)}
-        let!(:level_4) { create(:level, diagnostic: diagnostic)}
-        let!(:level_5) { create(:level, diagnostic: diagnostic)}
-        let!(:level_6) { create(:level, diagnostic: diagnostic)}
-        let!(:level_7) { create(:level, diagnostic: diagnostic)}
-        let!(:level_8) { create(:level, diagnostic: diagnostic)}
-        let!(:level_9) { create(:level, diagnostic: diagnostic)}
-        let!(:level_10) { create(:level, diagnostic: diagnostic)}
-        let!(:level_11) { create(:level, phonics_score: 92, number_of_tested_words: 100, diagnostic: diagnostic)}
+        let!(:level_1) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_2) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_3) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_4) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_5) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_6) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_7) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_8) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_9) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_10) { create(:level, diagnostic: first_diagnostic)}
+        let!(:level_11) { create(:level, phonics_score: 92, number_of_tested_words: 100, diagnostic: first_diagnostic)}
 
         it 'should return 11 as current reading level' do
-          expect(student.current_reading_level).to be(11)
+          expect(student.beginning_reading_level).to be(11)
         end
       end
 


### PR DESCRIPTION
Implement toggle for 4 diagnostic templates in the diagnostic creation page.

Added an index to the diagnostic model to determine 'first' and 'last' diagnostic templates. I decided to go with this implementation as I felt it was premature to introduce a diagnostic template table, and in the future, it would be possible to reuse a particular template in the 'first' or 'last' positions. Hence, by saving the appropriate index, it doesn't matter what template is used, and it is able to persist what intended order the templates were used. 

Implement javascript to allow front-end toggling of diagnostic templates and event listeners.

Refactored javascript methods into a more logical and clean file structure for ease of reading.

Change project#show to use view object for project and student to avoid excessive querying when calculating beginning and current reading level for students.

